### PR TITLE
Add a width hint to the commit template

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,3 +1,4 @@
+#<--           Max width of message           -->#
 # If applied, this commit will...
 
 


### PR DESCRIPTION
Messages wider the 50 chars don't always
render well in the terminal. So this gives a 
visual clue as to when you are going too
wide