### PR TITLE
lazy one-time-use via static method

### DIFF
--- a/src/Html2Markdown/Converter.cs
+++ b/src/Html2Markdown/Converter.cs
@@ -62,6 +62,8 @@ namespace Html2Markdown
 		{
 			return CleanWhiteSpace(_replacers.Aggregate(html, (current, element) => element.Replace(current)));
 		}
+		
+		public static string Convert(string html) => new Converter().Convert(html);
 
 		private static string CleanWhiteSpace(string markdown)
 		{


### PR DESCRIPTION
simple change for an inline one-time-use :: `Converter.Convert("some html")`