### PR TITLE
Remove AppVeyor Slack Integration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,8 +40,3 @@ on_finish:
   - ps: ./uploadTestResults.ps1
 artifacts:
 - path: src\Html2Markdown\bin\Release\*.nupkg
-notifications:
-  - provider: Slack
-    auth_token:
-      secure: xLrYwFJVzehV+sdSJsDp52X1TSPeSGJrr56LI2GQDvrmkpjcrwX1rmPwdH+i14H8lijQDcWbUt9jl81saehgRA==
-    channel: '#build'


### PR DESCRIPTION
This has stopped working and I don't really need it anymore.

Closes #91 