### PR TITLE
Fixed Error when parsing <pre>

### DIFF
--- a/src/Html2Markdown/Replacement/HtmlParser.cs
+++ b/src/Html2Markdown/Replacement/HtmlParser.cs
@@ -84,7 +84,7 @@ namespace Html2Markdown.Replacement
 		{
 			var tag = TabsToSpaces(html);
 			tag = IndentNewLines(tag);
-			return Environment.NewLine + Environment.NewLine + tag + Environment.NewLine;
+            return Environment.NewLine + Environment.NewLine + "```" + Environment.NewLine + tag + Environment.NewLine + "```" + Environment.NewLine;
 		}
 
 		private static string IndentNewLines(string tag)


### PR DESCRIPTION
When Parsing Markdown, Code-Blocks are denoted with "```" 
As reported in [This Issue ](https://github.com/baynezy/Html2Markdown/issues/90), And by myself using this code.
[Source](https://www.markdownguide.org/basic-syntax/#code-blocks-1)

