### PR TITLE
Fix a bug that added unsolicited new lines when parsing an ordered list containing paragraphs

### DIFF
--- a/src/Html2Markdown/Replacement/CommonMark/CommonMarkLayoutReplacementGroup.cs
+++ b/src/Html2Markdown/Replacement/CommonMark/CommonMarkLayoutReplacementGroup.cs
@@ -43,5 +43,5 @@ public class CommonMarkLayoutReplacementGroup : IReplacementGroup
 	public IEnumerable<IReplacer> Replacers()
 	{
 			return _replacements;
-		}
+	}
 }

--- a/src/Html2Markdown/Replacement/CommonMark/CommonMarkTextFormattingReplacementGroup.cs
+++ b/src/Html2Markdown/Replacement/CommonMark/CommonMarkTextFormattingReplacementGroup.cs
@@ -1,0 +1,73 @@
+namespace Html2Markdown.Replacement;
+
+/// <summary>
+/// A group of IReplacer to deal with converting HTML for
+/// formatting text
+/// </summary>
+public class CommonMarkTextFormattingReplacementGroup : IReplacementGroup
+{
+	private readonly IList<IReplacer> _replacements = new List<IReplacer> {
+		new PatternReplacer
+		{
+			Pattern = @"<(?:strong|b)>(\s+)",
+			Replacement = " **"
+		},
+		new PatternReplacer
+		{
+			Pattern = "<(?:strong|b)>",
+			Replacement = "**"
+		},
+		new PatternReplacer
+		{
+			Pattern = @"(\s+)</(strong|b)>",
+			Replacement = "** "
+		},
+		new PatternReplacer
+		{
+			Pattern = "</(strong|b)>",
+			Replacement = "**"
+		},
+		new PatternReplacer
+		{
+			Pattern = @"<(?:em|i)>(\s+)",
+			Replacement = " *"
+		},
+		new PatternReplacer
+		{
+			Pattern = "<(?:em|i)>",
+			Replacement = "*"
+		},
+		new PatternReplacer
+		{
+			Pattern = @"(\s+)</(em|i)>",
+			Replacement = "* "
+		},
+		new PatternReplacer
+		{
+			Pattern = "</(em|i)>",
+			Replacement = "*"
+		},
+		new CustomReplacer
+		{
+			CustomAction = HtmlParser.ReplaceImg
+		},
+		new CustomReplacer
+		{
+			CustomAction = ReplaceLists
+		},
+		new CustomReplacer
+		{
+			CustomAction = HtmlParser.ReplaceAnchor
+		}
+	};
+
+	private static string ReplaceLists(string html)
+	{
+		return HtmlParser.ReplaceLists(html, true);
+	}
+
+	public IEnumerable<IReplacer> Replacers()
+	{
+			return _replacements;
+		}
+}

--- a/src/Html2Markdown/Scheme/CommonMark.cs
+++ b/src/Html2Markdown/Scheme/CommonMark.cs
@@ -14,7 +14,7 @@ public class CommonMark : AbstractScheme
 {
     public CommonMark()
     {
-        AddReplacementGroup(ReplacerCollection, new TextFormattingReplacementGroup());
+        AddReplacementGroup(ReplacerCollection, new CommonMarkTextFormattingReplacementGroup());
         AddReplacementGroup(ReplacerCollection, new HeadingReplacementGroup());
         AddReplacementGroup(ReplacerCollection, new IllegalHtmlReplacementGroup());
         AddReplacementGroup(ReplacerCollection, new CommonMarkLayoutReplacementGroup());

--- a/test/Html2Markdown.Test/CommonMarkSchemeConverterTest.Convert_WhenThereIsAMultilineOrderedListWithNestedParagraphsAndCodeElement_ThenReplaceWithMarkdownLists.verified.txt
+++ b/test/Html2Markdown.Test/CommonMarkSchemeConverterTest.Convert_WhenThereIsAMultilineOrderedListWithNestedParagraphsAndCodeElement_ThenReplaceWithMarkdownLists.verified.txt
@@ -1,0 +1,6 @@
+﻿This code is with an ordered list and paragraphs.
+
+1.  Yes, this is a `code` element
+2.  No :
+
+    *   `Some code we are looking at`

--- a/test/Html2Markdown.Test/CommonMarkSchemeConverterTest.Convert_WhenThereIsAnOrderedListWithNestedParagraphs_ThenReplaceWithMarkdownLists.verified.txt
+++ b/test/Html2Markdown.Test/CommonMarkSchemeConverterTest.Convert_WhenThereIsAnOrderedListWithNestedParagraphs_ThenReplaceWithMarkdownLists.verified.txt
@@ -1,0 +1,6 @@
+﻿This code is with an ordered list and paragraphs.
+
+1.  Yes, this is a `code` element
+2.  No :
+
+    *   `Some code we are looking at`

--- a/test/Html2Markdown.Test/CommonMarkSchemeConverterTest.cs
+++ b/test/Html2Markdown.Test/CommonMarkSchemeConverterTest.cs
@@ -49,4 +49,30 @@ public class CommonMarkSchemeConverterTest : MarkdownSchemeConverterTest
 
         return CheckConversion(html);
     }
+
+    [Test]
+    public Task Convert_WhenThereIsAnOrderedListWithNestedParagraphs_ThenReplaceWithMarkdownLists()
+    {
+	    const string html = @"<p>This code is with an ordered list and paragraphs.</p><ol><li><p>Yes, this is a <code>code</code> element</p></li><li><p>No :</p><ul><li><code>Some code we are looking at</code></li></ul></li></ol>";
+
+	    return CheckConversion(html);
+    }
+
+    [Test]
+    public Task Convert_WhenThereIsAMultilineOrderedListWithNestedParagraphsAndCodeElement_ThenReplaceWithMarkdownLists()
+    {
+	    const string html = @"<p>This code is with an ordered list and paragraphs.</p>
+<ol>
+<li><p>Yes, this is a <code>code</code> element</p>
+</li>
+<li><p>No :</p>
+<ul>
+<li><code>Some code we are looking at</code></li>
+</ul>
+</li>
+</ol>
+";
+
+	    return CheckConversion(html);
+    }
 }


### PR DESCRIPTION
When converting an ordered list where items contain paragraphs, new lines are added in between each elements. 
This is a suggestion to fix this edge case.

## Description

Following the CommonMarks specs, if a list item contains multiple blocks, the item can be encapsulated in a paragraph tags.
See : [A list item may contain blocks that are separated by more than one blank line](https://spec.commonmark.org/0.30/#example-262)

Take the following example : 
```
This code is with an ordered list and paragraphs.

1.  Yes, this is a `code` element
2.  No :

    *   `Some code we are looking at`
```

[Using babelmark](https://babelmark.github.io/?text=This+code+is+with+an+ordered+list+and+paragraphs.%0A%0A1.++Yes%2C+this+is+a+%60code%60+element%0A2.++No+%3A%0A%0A++++*+++%60Some+code+we+are+looking+at%60), we can confirm that most implementations will translate it to the following code 
```html
<p>
  This code is with an ordered list and paragraphs.
</p>
<ol>
  <li>
    <p>
      Yes, this is a <code>code
      </code> element
    </p>
  </li>
  <li>
    <p>
      No :
    </p>
    <ul>
      <li>
        <code>
          Some code we are looking at
        </code>
      </li>
    </ul>
  </li>
</ol>
``` 

Providing this code to the online demo of Html2Markdown will return the following markdown : 

````
This code is with an ordered list and paragraphs. 

1.  

 Yes, this is a ``` code ``` element 
 >>New Line<<
2.  >>New Line<<
>>New Line<<
 No : 

    *   ```
          Some code we are looking at

```
````

To remove these new lines, I tried following the design we discussed earlier by : 
1. Adding a `CommonMarkTextFormattingReplacementGroup` class that will call `ReplaceList` with a flag indicating we want to be compliant with CommonMark
2. Used this newly created class in `CommonMark.cs` to replace the initial call of `TextFormattingReplacementGroup`

What are the changes within HtmlReplacer ? 
* `ReplaceLists` now accepts a `supportCommonMark` flag
* If the flag is set to true **AND** the currently processed item starts with a paragraph tag , we call `ReplaceParagraph` while we process the lists. Instead of calling it later as part of the replacement groups list. This will allow us to avoid adding new lines around the paragraph tags when they are part of a list item.
* Independently from the `supportCommonMark` flag, to handle multiline html, if a closing li tags is followed by a new line. We also remove this new line. This is done to prevent cases where this html 
`[...]<li><p>First Item</p>\\n</li>\\n<li>Second item[...]` becomes `[...]<li><p>First Item</p>\\n\\n<li>Second item[...]`, creating a double line break because we only removed the tag. L. 44
* Independently from the `supportCommonMark` flag, when aggregating the `markdownList` if we notice an item that is already ending with a new line, we do not add a new line. L. 66

Unfortunately there are multiple changes for this unique PR but I tried to fix things one after another as I was discovering them.

Do you think this is a legitimate change ? 

Also, do you think there is a  better way of handling the `Common Markdown` flag ? With some kind of static global variable ? This could prevent having to play with flags and instead set everything trough the `CommonMark` class.

## Related issue
N/A

Thanks.