### PR TITLE
Migrate documentation generation action

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: github-pages
     steps:
-      - uses: DenverCoder1/doxygen-github-pages-action@v1.3.0
+      - uses: baynezy/doxygen-github-pages-action@feature/specific-version
         with:
           github_token: ${{ secrets.PUBLISH_DOCS_TOKEN }}
           branch: gh-pages


### PR DESCRIPTION
The current version of https://github.com/DenverCoder1/doxygen-github-pages-action
only supports version doxygen version 1.9.1 which has a bug
doxygen/doxygen#9317 where file scoped namespaces are not supported.

I have forked the repo at https://github.com/baynezy/doxygen-github-pages-action
and modified it to install any version I want.

Closes #444
